### PR TITLE
Allow access to wp-login so that admins can login

### DIFF
--- a/SimpleWebsiteRedirect.php
+++ b/SimpleWebsiteRedirect.php
@@ -39,7 +39,9 @@ class SimpleWebsiteRedirect {
 	 * Primary functionality - handles website redirect based on current configuration.
 	 */
 	public static function _init() {
-		if ( ! is_admin() ) {
+		global $pagenow;
+		/* Allow requests to /wp-admin and wp-login so that admins can attempt to login */
+		if ( !is_admin() && $pagenow !== 'wp-login.php') {
 			$redirect_enabled = wp_validate_boolean( get_option( 'simple_website_redirect_status', false ) );
 			$redirect_url = self::sanitize_redirect_url( get_option( 'simple_website_redirect_url' ) );
 			if ( $redirect_enabled && ! empty( $redirect_url ) ) {


### PR DESCRIPTION
Your plugin did exactly what I needed, except one thing.

Requests to wp-login were getting redirected to the new site. In order to still allow access to wp-admin on the old site, I needed admins to be able to login.

Made use of the pagenow global variable as suggest by Codex.

Here's the example usage I followed: https://wp-time.com/wordpress-if-login-page/