### PR TITLE
Fix redirect queryParams - Ensure query parameters are preserved

### DIFF
--- a/SimpleWebsiteRedirect.php
+++ b/SimpleWebsiteRedirect.php
@@ -179,6 +179,12 @@ class SimpleWebsiteRedirect {
 					)
 				);
 			}
+
+			$query = $current_url->query;
+			if ( ! empty( $query ) ) {
+				$redirect_url->query = $query;
+			}
+
 			$url = $redirect_url->toString();
 		}
 

--- a/SimpleWebsiteRedirect.php
+++ b/SimpleWebsiteRedirect.php
@@ -180,10 +180,7 @@ class SimpleWebsiteRedirect {
 				);
 			}
 
-			$query = $current_url->query;
-			if ( ! empty( $query ) ) {
-				$redirect_url->query = $query;
-			}
+			$redirect_url->query = $current_url->query;
 
 			$url = $redirect_url->toString();
 		}


### PR DESCRIPTION
This PR ensures that when a URL is redirected, the query parameters from the original URL are preserved in the destination URL.